### PR TITLE
set timezone by changing /etc/localtime symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER tom@harhar.net
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "Europe/Berlin" > /etc/timezone && \
+RUN ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata
 
 RUN apt-get update && \
@@ -13,9 +13,9 @@ RUN apt-get -y install locales psmisc supervisor cron rsyslog wget mrtg apache2 
 
 RUN dpkg-reconfigure -f noninteractive locales
 RUN sed --in-place '/de_DE.UTF-8/s/^#//' /etc/locale.gen
-RUN locale-gen de_DE.UTF-8  
-ENV LANG de_DE.UTF-8  
-ENV LANGUAGE de_DE:de  
+RUN locale-gen de_DE.UTF-8
+ENV LANG de_DE.UTF-8
+ENV LANGUAGE de_DE:de
 ENV LC_ALL de_DE.UTF-8
 
 COPY assets/upnp2mrtg.sh /usr/local/bin
@@ -25,4 +25,3 @@ COPY assets/mrtg-cron /etc/cron.d/mrtg
 RUN rm /var/www/html/index.html
 
 CMD /bin/sh -c "service cron start; service apache2 start; while true; do echo Hello world; sleep 3600; done"
-


### PR DESCRIPTION
Set timezone by changing the `/etc/localtime` symlink (see also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=813226#10), the `dpkg-reconfigure` will then change `/etc/timezone`. Changing `/etc/timezone` and then running `dpkg-reconfigure` resets the timezone to UTC (for me).