### PR TITLE
Update Dockerfile to install netcat-openbsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime && \
 RUN apt-get update && \
     apt-get -y dist-upgrade
 
-RUN apt-get -y install locales psmisc supervisor cron rsyslog wget mrtg apache2 netcat
+RUN apt-get -y install locales psmisc supervisor cron rsyslog wget mrtg apache2 netcat-openbsd
 
 RUN dpkg-reconfigure -f noninteractive locales
 RUN sed --in-place '/de_DE.UTF-8/s/^#//' /etc/locale.gen


### PR DESCRIPTION
Package netcat is a virtual package provided by:
  netcat-openbsd 1.219-1
  netcat-traditional 1.10-47

E: Package 'netcat' has no installation candidate
The command '/bin/sh -c apt-get -y install locales psmisc supervisor cron rsyslog wget mrtg apache2 netcat' returned a non-zero code: 100